### PR TITLE
Get rid of renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
We actually don't need renovate because of the fix at https://blog.alphasmanifesto.com/2021/11/07/yarn-2-dependabot/ so we can actually use dependabot now :tada: 