### PR TITLE
Promisify read-package-tree

### DIFF
--- a/noticeme.ts
+++ b/noticeme.ts
@@ -4,9 +4,20 @@
 
 import readPkgTree from 'read-package-tree';
 
+
 import fs from 'fs';
 import fetch from 'node-fetch';
 import NoticeService from './noticeService';
+
+function rptPromise(rpt: typeof readPkgTree, path: string): Promise<readPkgTree.Node[]> {
+  return new Promise((resolve, reject) => {
+    rpt(path, (err, { children }) => {
+      if (err) reject(err)
+      resolve(children)
+    })
+  })
+
+}
 
 
 const npmjsCoordinates = ({ name, version }: { name: string, version: string }): string =>
@@ -28,37 +39,29 @@ function argNormalization(args: { path: string, includedFile: string | null, chu
 }
 
 
-
-export default function noticeme(args: { path: string, includedFile: string | null, chunkSize?: number | null, rpt?: typeof readPkgTree | null, http?: typeof fetch }): Promise<string> {
+export default async function noticeme(args: { path: string, includedFile: string | null, chunkSize?: number | null, rpt?: typeof readPkgTree | null, http?: typeof fetch }): Promise<string> {
   const { path, includedFile, chunkSize, rpt, http } = argNormalization(args);
-  return new Promise((resolve, reject) => {
-    rpt(path, function (err, { children }) {
-      if (err) reject(err);
+  const children = await rptPromise(rpt, path);
 
-      const pkgJsonLicenses = new Map();
-      let coordinates = children.map(({ package: pkg, children: more }) => {
-        children.push(...more);
-        const coordinate = npmjsCoordinates(pkg);
+  const pkgJsonLicenses = new Map();
+  let coordinates = children.map(({ package: pkg, children: more }) => {
+    children.push(...more);
+    const coordinate = npmjsCoordinates(pkg);
 
-        // TODO: make use of these as fallback
-        pkgJsonLicenses.set(coordinate, pkg.license);
+    // TODO: make use of these as fallback
+    pkgJsonLicenses.set(coordinate, pkg.license);
 
-        return coordinate;
-      });
-
-
-      if (includedFile) {
-        coordinates = coordinates.concat(retrieveIncludedJson(includedFile).
-          map((pkg) => npmjsCoordinates(pkg)));
-      }
-
-      const service = new NoticeService('https://api.clearlydefined.io/notices', http);
-      service.generateNotice(coordinates, chunkSize).then((json) =>
-        resolve(json.content)
-      ).catch((error: any) => {
-        reject(error);
-      })
-
-    });
+    return coordinate;
   });
+
+
+  if (includedFile) {
+    coordinates = coordinates.concat(retrieveIncludedJson(includedFile).
+      map((pkg) => npmjsCoordinates(pkg)));
+  }
+
+  const service = new NoticeService('https://api.clearlydefined.io/notices', http);
+
+  const json = await service.generateNotice(coordinates, chunkSize)
+  return json.content;
 }


### PR DESCRIPTION
Depends on #46

This allows us to use read-package-tree with promises. Arborist uses this so it's helpful to just have the same types.
