### PR TITLE
Update NPM packages for Sep 19, 2022

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-** typescript; version 4.7.4 -- https://www.typescriptlang.org/
+** typescript; version 4.8.3 -- https://www.typescriptlang.org/
 (c) by W3C
 Copyright (c) 2018 WHATWG
 Copyright (c) Microsoft Corporation
@@ -2707,16 +2707,15 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ** @types/diff-match-patch; version 1.0.32 -- 
 Copyright (c) Microsoft Corporation.
-** @types/lodash; version 4.14.182 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash
+** @types/lodash; version 4.14.185 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/lodash
 Copyright (c) Microsoft Corporation
-** @types/node; version 18.0.1 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+** @types/node; version 18.7.18 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
 Copyright (c) Microsoft Corporation
 ** @types/node-fetch; version 2.6.2 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node-fetch
 Copyright (c) Microsoft Corporation
 ** @types/read-package-tree; version 5.2.0 -- 
 Copyright (c) Microsoft Corporation.
-** @types/yargs; version 17.0.10 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs
-Copyright (c) Microsoft Corporation
+** @types/yargs; version 17.0.12 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs
 ** @types/yargs-parser; version 21.0.0 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/yargs-parser
 Copyright (c) Microsoft Corporation
 ** tr46; version 0.0.3 -- https://github.com/Sebmaster/tr46.js#readme

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/diff-match-patch": "^1.0.32",
-    "@types/lodash": "^4.14.182",
+    "@types/lodash": "^4.14",
     "@types/node": "^18.0.0",
     "@types/node-fetch": "^2.6.2",
     "@types/read-package-tree": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/diff-match-patch": "^1.0.32",
     "@types/lodash": "^4.14",
-    "@types/node": "^18.0.0",
+    "@types/node": "^18",
     "@types/node-fetch": "^2.6.2",
     "@types/read-package-tree": "^5.2.0",
     "@types/yargs": "^17",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "@types/node-fetch": "^2.6.2",
     "@types/read-package-tree": "^5.2.0",
     "@types/yargs": "^17.0.10",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^18.0.0",
     "@types/node-fetch": "^2.6.2",
     "@types/read-package-tree": "^5.2.0",
-    "@types/yargs": "^17.0.10",
+    "@types/yargs": "^17",
     "typescript": "^4.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@ __metadata:
     "@types/node": ^18.0.0
     "@types/node-fetch": ^2.6.2
     "@types/read-package-tree": ^5.2.0
-    "@types/yargs": ^17.0.10
+    "@types/yargs": ^17
     colors: ^1.4.0
     diff-match-patch: ^1.0.5
     lodash: ^4.17.21
@@ -72,12 +72,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.10":
-  version: 17.0.10
-  resolution: "@types/yargs@npm:17.0.10"
+"@types/yargs@npm:^17":
+  version: 17.0.12
+  resolution: "@types/yargs@npm:17.0.12"
   dependencies:
     "@types/yargs-parser": "*"
-  checksum: f0673cbfc08e17239dc58952a88350d6c4db04a027a28a06fbad27d87b670e909f9cd9e66f9c64cebdd5071d1096261e33454a55868395f125297e5c50992ca8
+  checksum: 5b41d21d8624199f89db82209b2adab2e47867b3677e852fde65698be2ca48364b14c2e70cb0adc9bca4a2102c93dad2409cae0ad666ea36ae031ae1cb08a7b5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,7 +11,7 @@ __metadata:
   dependencies:
     "@types/diff-match-patch": ^1.0.32
     "@types/lodash": ^4.14
-    "@types/node": ^18.0.0
+    "@types/node": ^18
     "@types/node-fetch": ^2.6.2
     "@types/read-package-tree": ^5.2.0
     "@types/yargs": ^17
@@ -51,10 +51,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^18.0.0":
+"@types/node@npm:*":
   version: 18.0.1
   resolution: "@types/node@npm:18.0.1"
   checksum: be14b251c54cc2b4ca78ac6eadf2fe5e831e487f2e17848f21d576295945b538271dcc674d0bba582b3f8d95b84f6826e99b6ba4710c76f165a8bdd4d4f0618e
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18":
+  version: 18.7.18
+  resolution: "@types/node@npm:18.7.18"
+  checksum: 8aec61f0f96e2a69ce51f1f40f949ca578bbb4fe05d7c0b8ce3aeeb848e90f755837f17f6ac132ca404d974fe9b2974150ad3b4984fc9dc7c3ceddb10bae0167
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@ __metadata:
     lodash: ^4.17.21
     node-fetch: ^2.6.7
     read-package-tree: ^5.3.1
-    typescript: ^4.7.4
+    typescript: ^4.8
     yargs: ^17.5.1
   bin:
     noticeme: cmd.js
@@ -909,23 +909,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.7.4":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:^4.8":
+  version: 4.8.3
+  resolution: "typescript@npm:4.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  checksum: 8286a5edcaf3d68e65c451aa1e7150ad1cf53ee0813c07ec35b7abdfdb10f355ecaa13c6a226a694ae7a67785fd7eeebf89f845da0b4f7e4a35561ddc459aba0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=7ad353"
+"typescript@patch:typescript@^4.8#~builtin<compat/typescript>":
+  version: 4.8.3
+  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
+  checksum: 0404a09c625df01934ef774b45ce1ca57ccae41cd625fcdbb82056715320d9329e70d9d75c2c732ec6ef947444ca978c189a332b71fa21f5c1437d5a83e24906
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@ __metadata:
   resolution: "@houdiniproject/noticeme@workspace:."
   dependencies:
     "@types/diff-match-patch": ^1.0.32
-    "@types/lodash": ^4.14.182
+    "@types/lodash": ^4.14
     "@types/node": ^18.0.0
     "@types/node-fetch": ^2.6.2
     "@types/read-package-tree": ^5.2.0
@@ -34,10 +34,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.14.182":
-  version: 4.14.182
-  resolution: "@types/lodash@npm:4.14.182"
-  checksum: 7dd137aa9dbabd632408bd37009d984655164fa1ecc3f2b6eb94afe35bf0a5852cbab6183148d883e9c73a958b7fec9a9bcf7c8e45d41195add6a18c34958209
+"@types/lodash@npm:^4.14":
+  version: 4.14.185
+  resolution: "@types/lodash@npm:4.14.185"
+  checksum: f81d13da5ecab110ca9c5c7cc2bedc3c9802a6acf668576aecd1b8f4b134ed81d06c15f1e600fb08f05975098280a0d97d30cddfc2cb39ec1c6b56e971ca53b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Update Typescript to 4.8
- Update @types/yargs to 17.0.12
- Update @types/lodash to 4.14.185
- Update @types/node to 18.7.18
- Update NOTICE
